### PR TITLE
update cluster numbers

### DIFF
--- a/cellset_extraction.R
+++ b/cellset_extraction.R
@@ -43,7 +43,7 @@ get_cellset_cell_ids <-
 #' Get the cell_ids for many cellsets
 #'
 #' The cellset coordinates follow the convention shown in get_cellset_cell_ids,
-#' so if you want the cell_ids of louvain clusters 13 and 14, you should input
+#' so if you want the cell_ids of louvain clusters 12 and 13, you should input
 #' list(c(1, 13), c(1,14)).
 #'
 #' @param cellsets list parsed json cellset object

--- a/remove_cellsets.Rmd
+++ b/remove_cellsets.Rmd
@@ -32,7 +32,7 @@ cellsets <- jsonlite::read_json(file.path(data_dir, "cellsets.json"))
 
 
 Create list of cellset coordinates to extract. Follow `get_cellset_cell_ids` docs
-for reference. In this example, we will remove louvain clusters (index 1) 13 and 14,
+for reference. In this example, we will remove louvain clusters (index 1) 12 and 13,
 
 ```{r}
 cellsets_to_extract <- list(c(1,13), c(1,14))


### PR DESCRIPTION
Louvain clusters are 0 based. This updates the comments to match the clusters that are actually selected in the example code.